### PR TITLE
fix: generate correct routes on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["20"]
+        platform: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Checkout repository
@@ -20,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node-version }}
 
       - name: Enable Corepack
         run: corepack enable

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ export async function listAstroRouteFiles(dir: string) {
   return files.map((el) => path.relative(dir, el));
 }
 
+export function normalizeSeparators(paths: string[]) {
+  return paths.map((routePath) => routePath.replaceAll(path.sep, "/"));
+}
+
 export function trimFileExtensions(paths: string[]) {
   return paths.map((path) => path.replace(/\.([^.]+)$/, ""));
 }
@@ -95,7 +99,8 @@ export async function formatPrettier(content: string) {
 
 export async function getRoutes(pagesDir: string) {
   const routeFiles = await listAstroRouteFiles(pagesDir);
-  const withoutExtension = trimFileExtensions(routeFiles);
+  const withNormalizedSeparators = normalizeSeparators(routeFiles);
+  const withoutExtension = trimFileExtensions(withNormalizedSeparators);
   const withoutIndex = trimIndex(withoutExtension);
   const withoutTrailingSlash = trimTrailingSlash(withoutIndex);
   const withLeading = addLeadingSlash(withoutTrailingSlash);


### PR DESCRIPTION
Normalize `\` path separators to `/` when generating routes to account for Windows path separators. Note that I also added Windows as a platform for CI tests (creating a minimal matrix as needed).

Closes #18 