### PR TITLE
Exclude redirects from resolved routes

### DIFF
--- a/packages/astro-typesafe-routes/src/integrations/astro-v5/index.ts
+++ b/packages/astro-typesafe-routes/src/integrations/astro-v5/index.ts
@@ -28,7 +28,7 @@ export async function getRoutes(
   args: GetRoutesParams,
 ): Promise<ResolvedRoute[]> {
   const withoutInternal = args.routes.filter(
-    (route) => route.origin !== "internal",
+    (route) => route.origin !== "internal" && route.type !== 'redirect',
   );
   const promises = withoutInternal.map(async (route) => {
     const absolutePath = path.join(args.rootDir, route.entrypoint);


### PR DESCRIPTION
This PR adjusts the `withoutInternal` filter to also filter out configured redirects originating from the Astro config file.

Fixes #58