### PR TITLE
Remove spread operator from Route params

### DIFF
--- a/packages/astro-typesafe-routes/src/integrations/astro-v5/index.ts
+++ b/packages/astro-typesafe-routes/src/integrations/astro-v5/index.ts
@@ -50,7 +50,7 @@ export async function getRoutes(
       );
 
     return {
-      path: route.pattern ?? "",
+      path: route.pattern,
       params: params.length > 0 ? params : null,
       absolutePath,
       hasSearchSchema,

--- a/packages/astro-typesafe-routes/src/integrations/astro-v5/index.ts
+++ b/packages/astro-typesafe-routes/src/integrations/astro-v5/index.ts
@@ -39,9 +39,19 @@ export async function getRoutes(
       ? await doesRouteHaveSearchSchema(absolutePath)
       : false;
 
+    const params = route.segments
+      .flatMap((segment) =>
+        // Only include dynamic segments (params)
+        segment.filter((routePart) => routePart.dynamic),
+      )
+      .map((routePart) =>
+        // Remove the ellipsis if it's a spread param
+        routePart.spread ? routePart.content.slice(3) : routePart.content,
+      );
+
     return {
       path: route.pattern ?? "",
-      params: route.params.length > 0 ? route.params : null,
+      params: params.length > 0 ? params : null,
       absolutePath,
       hasSearchSchema,
     };

--- a/packages/astro-typesafe-routes/src/path.ts
+++ b/packages/astro-typesafe-routes/src/path.ts
@@ -23,7 +23,7 @@ export function $path(args: RouteOptions) {
       url = url.replace(
         new RegExp(
           // Disregard spread operators when matching params
-          `\[(\.{3})?${paramKey}\]`,
+          `\\[(\\.{3})?${paramKey}\\]`,
         ),
         paramValue.toString(),
       );

--- a/packages/astro-typesafe-routes/src/path.ts
+++ b/packages/astro-typesafe-routes/src/path.ts
@@ -12,7 +12,7 @@ export type RouteOptions = {
 export function $path(args: RouteOptions) {
   const trailingSlash = args.trailingSlash ?? false;
 
-  let url: string = args.to;
+  let url = args.to;
 
   if (trailingSlash) {
     url += "/";
@@ -20,7 +20,13 @@ export function $path(args: RouteOptions) {
 
   if (args.params !== undefined) {
     for (const [paramKey, paramValue] of Object.entries(args.params)) {
-      url = url.replace(`[${paramKey}]`, paramValue.toString());
+      url = url.replace(
+        new RegExp(
+          // Disregard spread operators when matching params
+          `\[(\.{3})?${paramKey}\]`,
+        ),
+        paramValue.toString(),
+      );
     }
   }
 

--- a/packages/astro-typesafe-routes/tests/path.test.ts
+++ b/packages/astro-typesafe-routes/tests/path.test.ts
@@ -18,6 +18,15 @@ describe("$path", () => {
     ).toBe("/test/sv/123");
   });
 
+  it("handles spread params correctly", () => {
+    expect(
+      $path({
+        to: "/test/[...rest]",
+        params: { rest: "a/b/c" },
+      }),
+    ).toBe("/test/a/b/c");
+  });
+
   it("adds search params", () => {
     expect($path({ to: "/test", searchParams: { key: "value" } })).toBe(
       "/test?key=value",


### PR DESCRIPTION
This PR attempts to address #66. It's overall aim is to remove the spread operator `...` from route params so that the `getParams` util works correctly (see issue for more details).

`Link`s and `$path`s would have to be rewritten as follows:

```diff
<Link
  to="/test/[...rest]"
  params={{
-   ["...rest"]: "123",
+   rest: 123,
  }}
>
  click me
</Link>
```

This PR represents one possible approach to fixing the root issue of `getParams` not functioning correctly. The other way to go about this would be to add some additional logic into the `getParams` function so it grabs the correct value for the requested key.